### PR TITLE
fix: copy full repo when running local mode in repo-copier

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
-    "generate-build-local": "yarn generate-docs-local && yarn workspaces focus -A && yarn build",
+    "generate-build-local": "yarn generate-docs-local && yarn build",
     "generate-build-remote": "yarn generate-docs-remote && yarn workspaces focus -A && yarn build",
     "generate-docs-local": "yarn clean && yarn copy-repos-local && yarn add-tutorials",
     "generate-docs-remote": "yarn clean && yarn copy-repos-remote && yarn add-tutorials",

--- a/src/docs-generator/copy-utils.mjs
+++ b/src/docs-generator/copy-utils.mjs
@@ -65,15 +65,15 @@ export const cloneMinimalRepo = async(orgName, repo, fullRepoDirName) => {
     return { repoDirName, tagName };
 };
 
-/* Copy the src/ directory inside the repo to the
+/* Copy the repository root directory inside the repo to the
  * tempDirName directory with the name of the repository */
-export const copyRepoSrc = async(repoName, repoPath, destPath) => {
-    const originalRepoSrcPath = path.resolve(
-        `./${repoPath}/${repoName}/src`);
-    const repoSrcCopyPath = path.resolve(
+export const copyRepo = async(repoName, repoPath, destPath) => {
+    const originalRepoPath = path.resolve(
+        `./${repoPath}/${repoName}`);
+    const repoCopyPath = path.resolve(
         `./${destPath}/${repoName}`);
 
-    await cp(originalRepoSrcPath, repoSrcCopyPath, { recursive: true });
+    await cp(originalRepoPath, repoCopyPath, { recursive: true });
 
-    return { originalRepoSrcPath, repoSrcCopyPath };
+    return { originalRepoPath, repoCopyPath };
 };

--- a/src/docs-generator/repo-copier.mjs
+++ b/src/docs-generator/repo-copier.mjs
@@ -1,9 +1,8 @@
-import { rmSync } from "node:fs";
 import {
     ghVersion,
     getLatestRelease,
     cloneMinimalRepo,
-    copyRepoSrc
+    copyRepo
 } from "./copy-utils.mjs";
 
 // Organization name
@@ -31,26 +30,26 @@ if (process.argv.length !== 3 ||
 
 // Run "local" mode, using repositories from parent directory
 if (process.argv.includes(localMode)) {
-    const localReposPath = '../';
+    const localRepoPath = '../';
     console.info("Using local mode.");
-    // Copy src/ directories inside each repository
-    console.info(`Copying directories from "${localReposPath}"...`);
+    // Copy repo directories inside each repository
+    console.info(`Copying directories from "${localRepoPath}"...`);
 
-    const srcCopies = await Promise.all(
+    const repoCopies = await Promise.all(
         repositories.map(async (repo) => {
             try {
-                const {originalRepoSrcPath, repoSrcCopyPath} = await copyRepoSrc(
-                    repo.name, localReposPath, tempDirName);
+                const {originalRepoPath, repoCopyPath} = await copyRepo(
+                    repo.name, localRepoPath, tempDirName);
 
-                return `'${originalRepoSrcPath}' -> '${repoSrcCopyPath}'`;
+                return `'${originalRepoPath}' -> '${repoCopyPath}'`;
             } catch {
                 return '';
             }
         })
     );
 
-    console.info("Copied 'src/' directories");
-    console.info(srcCopies);
+    console.info("Copied repository directories");
+    console.info(repoCopies);
     
 }
 // Run "remote" mode, copying repositories remotely from GitHub
@@ -91,27 +90,6 @@ else if (process.argv.includes(remoteMode)) {
 
     console.info("Cloned repositories:");
     console.info(clonedBranches);
-
-    // Copy src/ directories inside each repository
-    /*
-    console.info("Copying 'src/' directories...");
-
-    const srcCopies = await Promise.all(
-        repositories.map(async (repo) => {
-            const {originalRepoSrcPath, repoSrcCopyPath} = await copyRepoSrc(
-                repo.name, fullRepoDirName, tempDirName);
-
-            return `'${originalRepoSrcPath}' -> '${repoSrcCopyPath}'`;
-        })
-    );
-
-    console.info("Copied 'src/' directories");
-    console.info(srcCopies);
-
-    // Delete temp/_repo directory since it's not needed anymore
-    console.info(`Removing ${fullRepoDirName} directory...`);
-    rmSync(fullRepoDirName, { recursive: true });
-    */
 }
 
 


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

This PR fixes a regression where the src/ directory was used for building docs, instead of the entire repository after the [package mode changes](https://github.com/IFCjs/docs/pull/15).

<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
