### PR TITLE
fix: create new docs building workflow PRs when PR status is not OPEN

### DIFF
--- a/.github/workflows/update-docs-projects.yml
+++ b/.github/workflows/update-docs-projects.yml
@@ -59,7 +59,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         run: |
           PR_EXISTS=$(gh pr view actions-generate-docs --json state -q '.state' || echo "no")
-          if [ "$PR_EXISTS" = "no" ] || [ "$PR_EXISTS" = "CLOSED" ]; then
+          if [ "$PR_EXISTS" = "no" ] || [ "$PR_EXISTS" != "OPEN" ]; then
             gh pr create --base main --title "chore(docs): generate documentation" \
               --body "This is an auto-generated PR for documentation updates made by GitHub Actions." \
               --head actions-generate-docs


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description
This PR improves the approach taken in https://github.com/IFCjs/docs/pull/27. Since there are two "closed" statuses (´{MERGED,CLOSED}`), it is a better solution to focus on creating PRs when the status is not `OPEN`.
<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
