### PR TITLE
fix: broken HelloWorldSchema iframe in schema docs (#39)

### DIFF
--- a/docs/fragments/schema.md
+++ b/docs/fragments/schema.md
@@ -46,9 +46,9 @@ Keep in this example we are **serializing ALL the data of the file to a JSON** j
 You might want to **revisit this example as a reference** when trying to generate your own fragment files from IFC STEP or other data sources to have a reference of how it should look like: 👇🏻
 
 <div style={{position: "relative"}}>
-<iframe src="https://thatopen.github.io/engine_fragment/examples/HelloWorldSchema/"></iframe>
+<iframe src="https://thatopen.github.io/engine_fragment/examples/IfcImporter/HelloWorldSchema/"></iframe>
 
-<button class="full-screen-btn" onClick={() => window.open("https://thatopen.github.io/engine_fragment/examples/HelloWorldSchema/")}> Go Full Screen</button>
+<button class="full-screen-btn" onClick={() => window.open("https://thatopen.github.io/engine_fragment/examples/IfcImporter/HelloWorldSchema/")}> Go Full Screen</button>
 </div>
 
 ## ✍🏻 General notes


### PR DESCRIPTION
Fixes the url for the fragment example in [The schema](https://docs.thatopen.com/fragments/schema#-check-it-out) document page in reference to issue #39 